### PR TITLE
fix: tabline not handling nils in HarpoonList.items

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,15 @@ By default, harpoon-tabline comes with these defaults:
 ---@field tab_prefix? string
 ---@field tab_suffix? string
 ---@field use_editor_color_scheme? boolean
----@field format_item_names? (fun(list: HarpoonList): string[])
+---@field empty_label? string
+---@field show_empty? boolean
+---@field format_item_names? (fun(list: {value: any}): string[])
 local config = {
     tab_prefix = " ",
     tab_suffix = " ",
     use_editor_color_scheme = true,
+    empty_label = "(empty)",
+    show_empty = true,
     format_item_names = utils.shorten_list_item_names,
 }
 ```
@@ -59,6 +63,8 @@ local config = {
 - `tab_prefix`/`tab_suffix`: Defines the prefix/suffix for each tab in your tabline.
 - `use_editor_color_scheme`: Enables/disables setting the highlight groups for
   the tabline to the default tabline highlight groups that your color scheme defines.
+- `empty_label`: What label to give empty items in the tabline.
+- `show_empty`: Whether to show empty items in the tabline.
 - `format_item_names`: A function that takes in a HarpoonList, and returns a
   string array that will be used as the content for the tabline.
   By default, this shortens the filepaths to the filename, unless there

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ By default, harpoon-tabline comes with these defaults:
 ---@field tab_prefix? string
 ---@field tab_suffix? string
 ---@field use_editor_color_scheme? boolean
----@field format_item_names? (fun(list: {value: any}): string[])
+---@field format_item_names? (fun(list: HarpoonList): string[])
 local config = {
     tab_prefix = " ",
     tab_suffix = " ",
@@ -59,9 +59,9 @@ local config = {
 - `tab_prefix`/`tab_suffix`: Defines the prefix/suffix for each tab in your tabline.
 - `use_editor_color_scheme`: Enables/disables setting the highlight groups for
   the tabline to the default tabline highlight groups that your color scheme defines.
-- `format_item_names`: A function that takes in the list of harpoon marks/list
-  items, and returns a string array that will be used as the content for the
-  tabline. By default, this shortens the filepaths to the filename, unless there
+- `format_item_names`: A function that takes in a HarpoonList, and returns a
+  string array that will be used as the content for the tabline.
+  By default, this shortens the filepaths to the filename, unless there
   are two matching file names. If there are two matching file names, the file
   path will be used instead.
 

--- a/lua/harpoon-tabline/init.lua
+++ b/lua/harpoon-tabline/init.lua
@@ -16,14 +16,14 @@ local M = {}
 ---@field tab_suffix? string
 ---@field use_editor_color_scheme? boolean
 ---@field empty_label? string
----@field hide_empty? boolean
+---@field show_empty? boolean
 ---@field format_item_names? (fun(list: {value: any}): string[])
 local config = {
     tab_prefix = " ",
     tab_suffix = " ",
     use_editor_color_scheme = true,
     empty_label = "(empty)",
-    hide_empty = false,
+    show_empty = true,
     format_item_names = utils.shorten_list_item_names,
 }
 
@@ -50,7 +50,7 @@ M.setup = function(args)
             local is_cur_buf
 
             if item == nil then
-                if M.config.hide_empty then
+                if not M.config.show_empty then
                     skip = true
                 else
                     item = M.config.empty_label

--- a/lua/harpoon-tabline/init.lua
+++ b/lua/harpoon-tabline/init.lua
@@ -43,20 +43,6 @@ M.setup = function(args)
         local cur_bufnr = vim.api.nvim_get_current_buf()
         local cur_buf_path = vim.api.nvim_buf_get_name(cur_bufnr)
         local cur_buf_abs_path = utils.get_abs_path(cur_buf_path)
-<<<<<<< Updated upstream
-
-        for i = 1, length do
-            local item = items_shortened[i]
-            local is_cur_buf
-
-            if item == nil then
-                item = "(nil)"
-                is_cur_buf = false
-            else
-                is_cur_buf = cur_buf_abs_path == utils.get_abs_path(list.items[i].value)
-            end
-=======
->>>>>>> Stashed changes
 
         for i = 1, length do
             local item = items_shortened[i]

--- a/lua/harpoon-tabline/init.lua
+++ b/lua/harpoon-tabline/init.lua
@@ -32,14 +32,24 @@ M.setup = function(args)
 
     function _G.tabline()
         local list = harpoon:list()
-        local items_shortened = M.config.format_item_names(list.items)
+        local length = list:length()
+        local items_shortened = M.config.format_item_names(list)
         local tabline = ""
 
         local cur_bufnr = vim.api.nvim_get_current_buf()
         local cur_buf_path = vim.api.nvim_buf_get_name(cur_bufnr)
         local cur_buf_abs_path = utils.get_abs_path(cur_buf_path)
-        for i, item in ipairs(items_shortened) do
-            local is_cur_buf = cur_buf_abs_path == utils.get_abs_path(list.items[i].value)
+
+        for i = 1, length do
+            local item = items_shortened[i]
+            local is_cur_buf
+
+            if item == nil then
+                item = "(nil)"
+                is_cur_buf = false
+            else
+                is_cur_buf = cur_buf_abs_path == utils.get_abs_path(list.items[i].value)
+            end
 
             local num_highlight_group = "%#" .. (is_cur_buf and "HarpoonNumberActive" or "HarpoonNumberInactive") .. "#"
             local item_highlight_group = "%#" .. (is_cur_buf and "HarpoonActive" or "HarpoonInactive") .. "#"

--- a/lua/harpoon-tabline/init.lua
+++ b/lua/harpoon-tabline/init.lua
@@ -15,11 +15,15 @@ local M = {}
 ---@field tab_prefix? string
 ---@field tab_suffix? string
 ---@field use_editor_color_scheme? boolean
+---@field empty_label? string
+---@field hide_empty? boolean
 ---@field format_item_names? (fun(list: {value: any}): string[])
 local config = {
     tab_prefix = " ",
     tab_suffix = " ",
     use_editor_color_scheme = true,
+    empty_label = "(empty)",
+    hide_empty = false,
     format_item_names = utils.shorten_list_item_names,
 }
 
@@ -39,6 +43,7 @@ M.setup = function(args)
         local cur_bufnr = vim.api.nvim_get_current_buf()
         local cur_buf_path = vim.api.nvim_buf_get_name(cur_bufnr)
         local cur_buf_abs_path = utils.get_abs_path(cur_buf_path)
+<<<<<<< Updated upstream
 
         for i = 1, length do
             local item = items_shortened[i]
@@ -50,24 +55,45 @@ M.setup = function(args)
             else
                 is_cur_buf = cur_buf_abs_path == utils.get_abs_path(list.items[i].value)
             end
+=======
+>>>>>>> Stashed changes
 
-            local num_highlight_group = "%#" .. (is_cur_buf and "HarpoonNumberActive" or "HarpoonNumberInactive") .. "#"
-            local item_highlight_group = "%#" .. (is_cur_buf and "HarpoonActive" or "HarpoonInactive") .. "#"
+        for i = 1, length do
+            local item = items_shortened[i]
+            local skip = false
+            local is_cur_buf
 
-            local tab = num_highlight_group
-                .. M.config.tab_prefix
-                .. i
-                .. " %*"
-                .. item_highlight_group
-                .. item
-                .. M.config.tab_suffix
-                .. "%*"
+            if item == nil then
+                if M.config.hide_empty then
+                    skip = true
+                else
+                    item = M.config.empty_label
+                end
 
-            if i < #items_shortened then
-                tab = tab .. "%T"
+                is_cur_buf = false
+            else
+                is_cur_buf = cur_buf_abs_path == utils.get_abs_path(list.items[i].value)
             end
 
-            tabline = tabline .. tab
+            if not skip then
+                local num_highlight_group = "%#" .. (is_cur_buf and "HarpoonNumberActive" or "HarpoonNumberInactive") .. "#"
+                local item_highlight_group = "%#" .. (is_cur_buf and "HarpoonActive" or "HarpoonInactive") .. "#"
+
+                local tab = num_highlight_group
+                    .. M.config.tab_prefix
+                    .. i
+                    .. " %*"
+                    .. item_highlight_group
+                    .. item
+                    .. M.config.tab_suffix
+                    .. "%*"
+
+                if i < #items_shortened then
+                    tab = tab .. "%T"
+                end
+
+                tabline = tabline .. tab
+            end
         end
 
         return tabline

--- a/lua/harpoon-tabline/init.lua
+++ b/lua/harpoon-tabline/init.lua
@@ -50,7 +50,7 @@ M.setup = function(args)
             local is_cur_buf
 
             if item == nil then
-                if not M.config.show_empty then
+                if not M.config.show_empty or length == 1 then
                     skip = true
                 else
                     item = M.config.empty_label

--- a/lua/harpoon-tabline/init.lua
+++ b/lua/harpoon-tabline/init.lua
@@ -17,7 +17,7 @@ local M = {}
 ---@field use_editor_color_scheme? boolean
 ---@field empty_label? string
 ---@field show_empty? boolean
----@field format_item_names? (fun(list: {value: any}): string[])
+---@field format_item_names? (fun(list: HarpoonList): string[])
 local config = {
     tab_prefix = " ",
     tab_suffix = " ",
@@ -62,7 +62,9 @@ M.setup = function(args)
             end
 
             if not skip then
-                local num_highlight_group = "%#" .. (is_cur_buf and "HarpoonNumberActive" or "HarpoonNumberInactive") .. "#"
+                local num_highlight_group = "%#"
+                    .. (is_cur_buf and "HarpoonNumberActive" or "HarpoonNumberInactive")
+                    .. "#"
                 local item_highlight_group = "%#" .. (is_cur_buf and "HarpoonActive" or "HarpoonInactive") .. "#"
 
                 local tab = num_highlight_group

--- a/lua/harpoon-tabline/utils.lua
+++ b/lua/harpoon-tabline/utils.lua
@@ -1,22 +1,32 @@
 local M = {}
 
----@param list {value: any}
+---@param list HarpoonList
 ---@return string[]
 M.shorten_list_item_names = function(list)
     local counts = {}
-    for _, list_item in ipairs(list) do
-        local name = vim.fn.fnamemodify(list_item.value, ":t")
-        counts[name or ""] = (counts[name] or 0) + 1
+    local length = list:length()
+
+    for i = 1, length do
+        local list_item = list.items[i]
+        if list_item ~= nil then
+            local name = vim.fn.fnamemodify(list_item.value, ":t")
+            counts[name or ""] = (counts[name] or 0) + 1
+        end
     end
 
     local shortened = {}
-    for _, file in ipairs(list) do
-        local name = vim.fn.fnamemodify(file.value, ":t")
-
-        if counts[name] == 1 then
-            table.insert(shortened, vim.fn.fnamemodify(name, ":t"))
+    for i = 1, length do
+        local file = list.items[i]
+        if file == nil then
+            table.insert(shortened, i, nil)
         else
-            table.insert(shortened, file.value)
+            local name = vim.fn.fnamemodify(file.value, ":t")
+
+            if counts[name] == 1 then
+                table.insert(shortened, i, vim.fn.fnamemodify(name, ":t"))
+            else
+                table.insert(shortened, i, file.value)
+            end
         end
     end
 


### PR DESCRIPTION
Since the list of items provided by harpoon2 can have `nil`s in it, this adds support for handling those.

To demonstrate, open three files (adding them all to harpoon), navigate to the second, then run
```lua
:lua require("harpoon"):list():remove()
```
Currently the tabline will stop at the first `nil` it finds (because of the usage of `ipair`) and just show the first item. This PR makes it so empty indices will just show `(nil)` in the tabline instead:

![Screenshot_20250425_053849](https://github.com/user-attachments/assets/9549882a-9219-42be-9549-89e567763223)

You could also make it not show these at all too, I guess? Maybe it could be added as a config argument

I changed the input type of `config.format_item_names` to take a `HarpoonList` since it exposes `HarpoonList:length()` which we can use to figure out the "real" length of the items list (including nils). That is obviously a breaking change, so maybe it could be done a different, cleaner way? Maybe add a "length" argument to it? I'm also a beginner at lua so hopefully it's not too messy